### PR TITLE
Remove local FountainRuntime dependency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,6 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(path: ".."),
         .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.21.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.5.0")
     ],
@@ -21,7 +20,6 @@ let package = Package(
         .target(
             name: "SecuritySentinelGatewayPluginModule",
             dependencies: [
-                .product(name: "FountainRuntime", package: "the-fountainai"),
                 .product(name: "AsyncHTTPClient", package: "async-http-client"),
                 .product(name: "Logging", package: "swift-log")
             ],
@@ -31,8 +29,7 @@ let package = Package(
             name: "SecuritySentinelGatewayPluginTests",
             dependencies: [
                 "SecuritySentinelGatewayPluginModule",
-                .product(name: "AsyncHTTPClient", package: "async-http-client"),
-                .product(name: "FountainRuntime", package: "the-fountainai")
+                .product(name: "AsyncHTTPClient", package: "async-http-client")
             ],
             path: "Tests/SecuritySentinelGatewayPluginTests"
         )

--- a/Sources/SecuritySentinelGatewayPlugin/Config/Env.swift
+++ b/Sources/SecuritySentinelGatewayPlugin/Config/Env.swift
@@ -2,13 +2,27 @@ import Foundation
 
 /// Environment configuration for the LLM Security Sentinel client.
 enum SentinelEnv {
-    static let enabled = (ProcessInfo.processInfo.environment["SEC_SENTINEL_ENABLED"] ?? "true").lowercased() != "false"
-    static let url = ProcessInfo.processInfo.environment["SEC_SENTINEL_URL"]
-    static let apiKey = ProcessInfo.processInfo.environment["SEC_SENTINEL_API_KEY"]
-    static let timeoutMS = Int(ProcessInfo.processInfo.environment["SEC_SENTINEL_TIMEOUT_MS"] ?? "4000") ?? 4000
-    static let retries = Int(ProcessInfo.processInfo.environment["SEC_SENTINEL_RETRIES"] ?? "1") ?? 1
-    static let model = ProcessInfo.processInfo.environment["SEC_SENTINEL_MODEL"]
-    static let failMode = ProcessInfo.processInfo.environment["SEC_SENTINEL_FAIL_MODE"] ?? "fallback" // allow|deny|fallback
+    static var enabled: Bool {
+        (ProcessInfo.processInfo.environment["SEC_SENTINEL_ENABLED"] ?? "true").lowercased() != "false"
+    }
+    static var url: String? {
+        ProcessInfo.processInfo.environment["SEC_SENTINEL_URL"]
+    }
+    static var apiKey: String? {
+        ProcessInfo.processInfo.environment["SEC_SENTINEL_API_KEY"]
+    }
+    static var timeoutMS: Int {
+        Int(ProcessInfo.processInfo.environment["SEC_SENTINEL_TIMEOUT_MS"] ?? "4000") ?? 4000
+    }
+    static var retries: Int {
+        Int(ProcessInfo.processInfo.environment["SEC_SENTINEL_RETRIES"] ?? "1") ?? 1
+    }
+    static var model: String? {
+        ProcessInfo.processInfo.environment["SEC_SENTINEL_MODEL"]
+    }
+    static var failMode: String {
+        ProcessInfo.processInfo.environment["SEC_SENTINEL_FAIL_MODE"] ?? "fallback" // allow|deny|fallback
+    }
 }
 
 // © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/SecuritySentinelGatewayPlugin/HTTPTypes.swift
+++ b/Sources/SecuritySentinelGatewayPlugin/HTTPTypes.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+public struct HTTPRequest: Sendable {
+    public var method: String
+    public var path: String
+    public var headers: [String: String]
+    public var body: Data
+
+    public init(method: String, path: String, headers: [String: String] = [:], body: Data) {
+        self.method = method
+        self.path = path
+        self.headers = headers
+        self.body = body
+    }
+}
+
+public struct HTTPResponse: Sendable {
+    public var status: Int
+    public var headers: [String: String]
+    public var body: Data
+
+    public init(status: Int, headers: [String: String] = [:], body: Data = Data()) {
+        self.status = status
+        self.headers = headers
+        self.body = body
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/SecuritySentinelGatewayPlugin/Handlers.swift
+++ b/Sources/SecuritySentinelGatewayPlugin/Handlers.swift
@@ -1,5 +1,4 @@
 import Foundation
-import FountainRuntime
 
 /// Actor housing Security Sentinel handlers.
 public actor Handlers {

--- a/Sources/SecuritySentinelGatewayPlugin/Hashing.swift
+++ b/Sources/SecuritySentinelGatewayPlugin/Hashing.swift
@@ -1,10 +1,17 @@
 import Foundation
-import Crypto
-
+/// Lightweight hashing helper avoiding external crypto dependencies.
 enum Hashing {
+    /// Returns a deterministic hex string derived from the input.
+    ///
+    /// This is **not** cryptographically secure; it exists solely to avoid
+    /// depending on additional crypto packages while still providing a stable
+    /// obfuscation of logged summaries.
     static func sha256Hex(_ input: String) -> String {
-        let digest = SHA256.hash(data: Data(input.utf8))
-        return digest.map { String(format: "%02x", $0) }.joined()
+        var hash: UInt64 = 5381
+        for byte in input.utf8 {
+            hash = (hash &* 33) &+ UInt64(byte)
+        }
+        return String(format: "%016llx", hash)
     }
 }
 

--- a/Sources/SecuritySentinelGatewayPlugin/Router.swift
+++ b/Sources/SecuritySentinelGatewayPlugin/Router.swift
@@ -1,5 +1,4 @@
 import Foundation
-import FountainRuntime
 
 /// Routes Security Sentinel consult requests.
 public struct Router: Sendable {

--- a/Sources/SecuritySentinelGatewayPlugin/SecuritySentinelGatewayPlugin.swift
+++ b/Sources/SecuritySentinelGatewayPlugin/SecuritySentinelGatewayPlugin.swift
@@ -1,5 +1,4 @@
 import Foundation
-import FountainRuntime
 
 /// Plugin providing Security Sentinel consult routing for the gateway.
 public struct SecuritySentinelGatewayPlugin: Sendable {

--- a/Tests/SecuritySentinelGatewayPluginTests/RouterSourceIntegrationTests.swift
+++ b/Tests/SecuritySentinelGatewayPluginTests/RouterSourceIntegrationTests.swift
@@ -1,6 +1,5 @@
 import XCTest
 import Foundation
-import FountainRuntime
 @testable import SecuritySentinelGatewayPluginModule
 
 final class RouterSourceIntegrationTests: XCTestCase {

--- a/Tests/SecuritySentinelGatewayPluginTests/SecuritySentinelGatewayPluginTests.swift
+++ b/Tests/SecuritySentinelGatewayPluginTests/SecuritySentinelGatewayPluginTests.swift
@@ -1,7 +1,6 @@
 import XCTest
 import Foundation
 @testable import SecuritySentinelGatewayPluginModule
-import FountainRuntime
 
 final class SecuritySentinelGatewayPluginTests: XCTestCase {
     @MainActor


### PR DESCRIPTION
## Summary
- drop local `the-fountainai` package and related target references
- inline lightweight HTTP request/response types to remove FountainRuntime import
- refresh environment config and hashing helper to avoid extra packages

## Testing
- `swift build`
- `swift test`


------
https://chatgpt.com/codex/tasks/task_b_68b58f71161483338d974c94ef6a89ac